### PR TITLE
fix(renovate.json): don't pin GitHub actions workflows to specific SHA hash

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,11 @@
     ":prConcurrentLimit10",
     ":rebaseStalePrs",
     ":pinDependencies"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinVersions": false
+    }
   ]
 }


### PR DESCRIPTION
With `actions/setup-node@v4` it's immediately clear what the version is supposed to be.

This is not the case with `actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b`.